### PR TITLE
bugfix: generated UUID from each factory should be independent

### DIFF
--- a/lib/resty/jit-uuid.lua
+++ b/lib/resty/jit-uuid.lua
@@ -274,13 +274,14 @@ do
             end
 
             assert(i == 16, "invalid binary namespace buffer length")
+            local ns = concat(buf)
 
             return function(name)
                 if type(name) ~= 'string' then
                     return nil, 'name must be a string'
                 end
 
-                local hash, ver, var = hash_fn(concat(buf, ''), name)
+                local hash, ver, var = hash_fn(ns, name)
 
                 return (fmt('%s-%s-%s%s-%s%s-%s', sub(hash, 1, 8),
                                                 sub(hash, 9, 12),

--- a/t/05-v5.t
+++ b/t/05-v5.t
@@ -198,3 +198,27 @@ qr/\[TRACE   \d+ content_by_lua\(nginx\.conf:\d+\):6 loop\]/
 --- no_error_log
 [error]
 -- NYI:
+
+
+
+=== TEST 9: generated UUID from each factory should be independent
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local uuid = require 'resty.jit-uuid'
+
+            local factory = uuid.factory_v5('1b985f4a-06be-11e6-aff4-ff8d14e25128')
+            ngx.say(factory('hello'))
+
+            uuid.factory_v5('e6ebd542-06ae-11e6-8e82-bba81706b27d')
+            ngx.say(factory('hello'))
+        }
+    }
+--- request
+GET /t
+--- response_body
+e90a1bfc-d349-5ec0-89fe-b29f2419624b
+e90a1bfc-d349-5ec0-89fe-b29f2419624b
+--- no_error_log
+[error]


### PR DESCRIPTION
The buffer should not be shared among factories. By removing the concat
out of each call, we also speed up the generation.