### PR TITLE
Switch to cloning using git+https

### DIFF
--- a/lua-resty-jit-uuid-0.0.7-2.rockspec
+++ b/lua-resty-jit-uuid-0.0.7-2.rockspec
@@ -1,7 +1,7 @@
 package = "lua-resty-jit-uuid"
-version = "0.0.7-1"
+version = "0.0.7-2"
 source = {
-  url = "git://github.com/thibaultcha/lua-resty-jit-uuid",
+  url = "git+https://github.com/thibaultcha/lua-resty-jit-uuid",
   tag = "0.0.7"
 }
 description = {


### PR DESCRIPTION
Typically, cloning via https works well with restricted network environments - I've found the default 'git' protocol port to be blocked pretty often.